### PR TITLE
Go Module and remove github.com/juju/errors 

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -2,6 +2,7 @@ package pongo2addons
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -13,8 +14,7 @@ import (
 
 	"github.com/extemporalgenome/slug"
 	"github.com/flosch/go-humanize"
-	"github.com/juju/errors"
-	"github.com/russross/blackfriday"
+	"github.com/russross/blackfriday/v2"
 )
 
 func init() {
@@ -40,7 +40,7 @@ func init() {
 }
 
 func filterMarkdown(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
-	return pongo2.AsSafeValue(string(blackfriday.MarkdownCommon([]byte(in.String())))), nil
+	return pongo2.AsSafeValue(string(blackfriday.Run([]byte(in.String())))), nil
 }
 
 func filterSlugify(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/flosch/pongo2-addons
+
+go 1.14
+
+require (
+	github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0
+	github.com/flosch/go-humanize v0.0.0-20140728123800-3ba51eabe506
+	github.com/flosch/pongo2 v0.0.0-20200529170236-5abacdfa4915
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/russross/blackfriday/v2 v2.0.1
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0 h1:0A9+8DBvlpto0mr+SD1NadV5liSIAZkWnvyshwk88Bc=
+github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0/go.mod h1:96eSBMO0aE2dcsEygXzIsvGyOf7bM5kWuqVCPEgwLEI=
+github.com/flosch/go-humanize v0.0.0-20140728123800-3ba51eabe506 h1:tN043XK9BV76qc31Z2GACIO5Dsh99q21JtYmR2ltXBg=
+github.com/flosch/go-humanize v0.0.0-20140728123800-3ba51eabe506/go.mod h1:pSiPkAThBLWmIzJ2fukUGkcxxWR4HoLT7Bp8/krrl5g=
+github.com/flosch/pongo2 v0.0.0-20200529170236-5abacdfa4915 h1:rNVrewdFbSujcoKZifC6cHJfqCTbCIR7XTLHW5TqUWU=
+github.com/flosch/pongo2 v0.0.0-20200529170236-5abacdfa4915/go.mod h1:fB4mx6dzqFinCxIf3a7Mf5yLk+18Bia9mPAnuejcvDA=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
- https://github.com/flosch/pongo2/issues/223
- https://github.com/kataras/iris/issues/1401
- https://github.com/flosch/pongo2/pull/236#issuecomment-668953009

Also, the blackfriday package updated to its /v2 new import path.

EDIT: When this PR: https://github.com/flosch/pongo2/pull/240 is merged, the master version of go.mod:pongo2 SHOULD be upgraded as well. 

To avoid this behavior: make flosch/pongo2 a go module with path suffix such as `github.com/flosch/pongo2/v4` which requires a new **v4.0.0 release** (there is already a version 3 branch and an announcement), so we don't have to change this every time the pongo2 repository gets a minor upgrade.


/CC @flosch @jclc